### PR TITLE
Fractional balancing; simplification

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+[*.js]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/text-balancer.js
+++ b/text-balancer.js
@@ -23,7 +23,7 @@ var textBalancer = function (selectors) {
 // this populates our candidates array with dom objects
 // that need to be balanced
 var createSelectors = function(selectors) {
-    selectorArray = selectors.split(',');
+    var selectorArray = selectors.split(',');
     for (var i = 0; i < selectorArray.length; i += 1) {
         var currentSelectorElements = document.querySelectorAll(selectorArray[i].trim());
 

--- a/text-balancer.js
+++ b/text-balancer.js
@@ -61,12 +61,8 @@ var balanceText = function () {
 
     for (i = 0; i < candidates.length; i += 1) {
         element = candidates[i];
-
-        if (textElementIsMultipleLines(element)) {
-            element.style.maxWidth = '';
-            squeezeContainer(element, element.clientHeight, 0, element.clientWidth);
-        }
-
+        element.style.maxWidth = '';
+        squeezeContainer(element, element.clientHeight, 0, element.clientWidth);
     }
 
 }
@@ -89,66 +85,5 @@ var squeezeContainer = function (element, originalHeight, bottomRange, topRange)
         squeezeContainer(element, originalHeight, bottomRange+1, mid);
     }
 }
-
-// function to see if a headline is multiple lines
-// we only want to break if the headline is multiple lines
-//
-// We achieve this by turning the first word into a span
-// and then we compare the height of that span to the height
-// of the entire headline. If the headline is bigger than the
-// span by 10px we balance the headline.
-var textElementIsMultipleLines = function (element) {
-    var firstWordHeight;
-    var elementHeight;
-    var HEIGHT_OFFSET;
-    var elementWords;
-    var firstWord;
-    var ORIGINAL_ELEMENT_TEXT;
-
-    ORIGINAL_ELEMENT_TEXT = element.innerHTML;
-
-    // usually there is around a 5px discrepency between
-    // the first word and the height of the whole headline
-    // so subtract the height of the headline by 10 px and
-    // we should be good
-    HEIGHT_OFFSET = 10;
-
-    // get all the words in the headline as
-    // an array -- will include punctuation
-    //
-    // this is used to put the headline back together
-    elementWords = element.innerHTML.split(' ');
-
-    // make span for first word and give it an id
-    // so we can access it in le dom
-    firstWord = document.createElement('span');
-    firstWord.id = 'element-first-word';
-    firstWord.innerHTML = elementWords[0];
-
-    // this is the entire headline
-    // as an array except for first word
-    //
-    // we will append it to the headline after the span
-    elementWords = elementWords.slice(1);
-
-    // empty the headline and append the span to it
-    element.innerHTML = '';
-    element.appendChild(firstWord);
-
-    // add the rest of the element back to it
-    element.innerHTML += ' ' + elementWords.join(' ');
-
-    // update the first word variable in the dom
-    firstWord = document.getElementById('element-first-word');
-
-    firstWordHeight = firstWord.offsetHeight;
-    elementHeight = element.offsetHeight;
-    // restore the original element text
-    element.innerHTML = ORIGINAL_ELEMENT_TEXT;
-
-    // compare the height of the element and the height of the first word
-    return elementHeight - HEIGHT_OFFSET > firstWordHeight;
-
-} // end headlineIsMultipleLines
 
 exports.balanceText = textBalancer;

--- a/text-balancer.js
+++ b/text-balancer.js
@@ -64,7 +64,11 @@ var balanceText = function () {
         clearMaxWidth(element);
         var computedStyle = getComputedStyle(element, null);
         if (computedStyle.textAlign === 'start') { // only squeeze left-aligned elements
-            squeezeContainerLeft(element, element.clientHeight, 0, element.clientWidth);
+            // In an n-line element, at most roughly 1/n'th of the horizontal width
+            // can be "visually recoverable," so half is our starting minimum
+            // (minus a fudge factor, with a minimum of 50).
+            var bottomRange = Math.max(50, element.offsetWidth / 2 - 10);
+            squeezeContainerLeft(element, element.clientHeight, bottomRange, element.clientWidth);
         }
     }
 }

--- a/text-balancer.js
+++ b/text-balancer.js
@@ -61,14 +61,28 @@ var balanceText = function () {
 
     for (i = 0; i < candidates.length; i += 1) {
         element = candidates[i];
-        element.style.maxWidth = '';
-        squeezeContainer(element, element.clientHeight, 0, element.clientWidth);
+        clearMaxWidth(element);
+        var computedStyle = getComputedStyle(element, null);
+        if (computedStyle.textAlign === 'start') { // only squeeze left-aligned elements
+            squeezeContainerLeft(element, element.clientHeight, 0, element.clientWidth);
+        }
     }
-
 }
 
-// Make the element as narrow as possible while maintaining its current height (number of lines). Binary search.
-var squeezeContainer = function (element, originalHeight, bottomRange, topRange) {
+var clearMaxWidth = function (element) {
+    // For now, this library assumes it is the keeper of all maxWidth
+    // values in its DOM elements. If this element has a computed style
+    // of 'center' (or anything besides 'start' aka left), that must
+    // be because the window was shrunk and we responsively made it
+    // left-justified and this library assigned it a maxWidth. If we
+    // expand the window again, we need to reevaluate all maxWidths.
+    // We start by erasing our previous work.
+    element.style.maxWidth = '';
+}
+
+// Make the element as narrow as possible (by leaving the left side anchored and
+// reducing the width) while maintaining its current height (number of lines). Binary search.
+var squeezeContainerLeft = function (element, originalHeight, bottomRange, topRange) {
     var mid;
     if (bottomRange >= topRange) {
         element.style.maxWidth = topRange + 'px';
@@ -79,10 +93,10 @@ var squeezeContainer = function (element, originalHeight, bottomRange, topRange)
 
     if (element.clientHeight > originalHeight) {
         // we've squoze too far and element has spilled onto an additional line; recurse on wider range
-        squeezeContainer(element, originalHeight, mid+1, topRange);
+        squeezeContainerLeft(element, originalHeight, mid+1, topRange);
     } else {
         // element has not wrapped to another line; keep squeezing!
-        squeezeContainer(element, originalHeight, bottomRange+1, mid);
+        squeezeContainerLeft(element, originalHeight, bottomRange+1, mid);
     }
 }
 

--- a/text-balancer.js
+++ b/text-balancer.js
@@ -97,7 +97,7 @@ var squeezeContainerLeft = function (element, originalHeight, originalWidth, bot
     // If we get within 5 pixels that's close enough, we don't need to
     // do the last 2 iterations. Call topRange the new minimum width.
     if (bottomRange + 5 >= topRange) {
-        element.style.maxWidth = Math.round(originalWidth - fraction*(originalWidth-topRange)).toString() + 'px';
+        element.style.maxWidth = Math.ceil(originalWidth - fraction*(originalWidth-topRange)).toString() + 'px';
         return;
     }
 

--- a/text-balancer.js
+++ b/text-balancer.js
@@ -3,12 +3,19 @@ var candidates = [];
 // pass in a string of selectors to be balanced.
 // if you didnt specify any, thats ok! We'll just
 // balance anything with the balance-text class
-var textBalancer = function (selectors, fraction) {
+var textBalancer = function (selectors, fraction=1.0) {
 
     if (!selectors) {
         candidates = document.querySelectorAll('.balance-text');
     } else {
         createSelectors(selectors);
+    }
+    fraction = +fraction;
+    if ((typeof fraction) != 'number' || isNaN(fraction)) {
+        fraction = 1.0;
+    } else {
+        fraction = Math.max(0.0, Math.min(1.0, fraction))
+        if (fraction == 0.0) return;
     }
 
     balanceText(fraction);

--- a/text-balancer.js
+++ b/text-balancer.js
@@ -83,12 +83,15 @@ var clearMaxWidth = function (element) {
 // Make the element as narrow as possible (by leaving the left side anchored and
 // reducing the width) while maintaining its current height (number of lines). Binary search.
 var squeezeContainerLeft = function (element, originalHeight, bottomRange, topRange) {
-    var mid;
-    if (bottomRange >= topRange) {
-        element.style.maxWidth = topRange + 'px';
+    // If we get within 5 pixels that's close enough, we don't need to
+    // do the last 2 iterations. Call topRange the new minimum width.
+    if (bottomRange + 5 >= topRange) {
+        element.style.maxWidth = Math.round(topRange).toString() + 'px';
         return;
     }
-    mid = (bottomRange + topRange) / 2;
+
+    // Otherwise, pick the midpoint (maybe fractional) and squeeze to that size.
+    var mid = (bottomRange + topRange) / 2;
     element.style.maxWidth = mid + 'px';
 
     if (element.clientHeight > originalHeight) {

--- a/text-balancer.js
+++ b/text-balancer.js
@@ -103,7 +103,7 @@ var squeezeContainerLeft = function (element, originalHeight, bottomRange, topRa
         squeezeContainerLeft(element, originalHeight, mid+1, topRange);
     } else {
         // element has not wrapped to another line; keep squeezing!
-        squeezeContainerLeft(element, originalHeight, bottomRange+1, mid);
+        squeezeContainerLeft(element, originalHeight, bottomRange, mid);
     }
 }
 

--- a/text-balancer.js
+++ b/text-balancer.js
@@ -108,10 +108,10 @@ var squeezeContainerLeft = function (element, originalHeight, originalWidth, bot
 
     if (element.clientHeight > originalHeight) {
         // we've squoze too far and element has spilled onto an additional line; recurse on wider range
-        squeezeContainerLeft(element, originalHeight, originalWidth, mid+1, topRange, fraction);
+        squeezeContainerLeft(element, originalHeight, originalWidth, mid, topRange, fraction);
     } else {
         // element has not wrapped to another line; keep squeezing!
-        squeezeContainerLeft(element, originalHeight, originalWidth, bottomRange+1, mid, fraction);
+        squeezeContainerLeft(element, originalHeight, originalWidth, bottomRange, mid, fraction);
     }
 }
 


### PR DESCRIPTION
### Summary

These are the changes that Vox Media has used for text-balancer. This version is approximately what's been running on vox.com for some time now.

We'd like to thank you for open-sourcing this library, and submit these changes back upstream for your consideration.

The main change is that there's a new argument to apply only a fraction of the maximum change. On vox.com, we determine how much each headline can be squeezed, and then only squeeze it half that much. We find this to be a visually appealing tradeoff. This new argument is optional and backwards-compatible.

### Fractional squeezing

Here is a crude animation to show the effect of different fractional values. `0.00` is the same as not enabling text-balancer at all; `1.00` is the same as text-balancer without this PR applied.

![vox-balanced-headlines](https://user-images.githubusercontent.com/40373/31089870-f17ec246-a7a5-11e7-9bac-158ef6a78cb9.gif)

### Other changes

This PR also proposes a performance improvement and simplification: the removal of `textElementIsMultipleLines`. It's a good idea, but in my testing, running this function took about the same time as simply running `squeezeContainer`, so removing it should make things run slightly faster. For details, see the commit message on 6f2b7a729b0d.

As an additional performance enhancement, this tweaks the beginning and end of the recursive function to not run quite as long. Squeezing beyond 50% is never necessary because in the only case where it's possible (single line) there is no visual difference. So we start at 50% instead of 0%. And halting the loop once the range is down to 5 pixels saves another couple of iterations at a small cost in accuracy.

Finally, this PR adds a check before trying to squeeze an element, to make sure that its text is left-aligned. The algorithm could be changed to work with center- and right-aligned divs, but as written, its results would look pretty ugly on them. For now, the algorithm should only be applied to those aligned left. It's a simple `getComputedStyle` check, which I think is pretty compatible, though [this 2010 comment](https://stackoverflow.com/questions/2664045/how-to-get-an-html-elements-style-values-in-javascript/2664055#2664055) suggests there's a workaround for an MSIE incompatibility. I don't know how well this works with IE. (Hat tip to @bceskavich for help with this.)