### PR TITLE
Determine multi-line with getComputedStyle

### DIFF
--- a/text-balancer.standalone.js
+++ b/text-balancer.standalone.js
@@ -93,64 +93,12 @@ textBalancer = (function () {
 
     // function to see if a headline is multiple lines
     // we only want to break if the headline is multiple lines
-    //
-    // We achieve this by turning the first word into a span
-    // and then we compare the height of that span to the height
-    // of the entire headline. If the headline is bigger than the
-    // span by 10px we balance the headline.
     var textElementIsMultipleLines = function (element) {
-        var firstWordHeight;
-        var elementHeight;
-        var HEIGHT_OFFSET;
-        var elementWords;
-        var firstWord;
-        var ORIGINAL_ELEMENT_TEXT;
-
-        ORIGINAL_ELEMENT_TEXT = element.innerHTML;
-
-        // usually there is around a 5px discrepency between
-        // the first word and the height of the whole headline
-        // so subtract the height of the headline by 10 px and
-        // we should be good
-        HEIGHT_OFFSET = 10;
-
-        // get all the words in the headline as
-        // an array -- will include punctuation
-        //
-        // this is used to put the headline back together
-        elementWords = element.innerHTML.split(' ');
-
-        // make span for first word and give it an id
-        // so we can access it in le dom
-        firstWord = document.createElement('span');
-        firstWord.id = 'element-first-word';
-        firstWord.innerHTML = elementWords[0];
-
-        // this is the entire headline
-        // as an array except for first word
-        //
-        // we will append it to the headline after the span
-        elementWords = elementWords.slice(1);
-
-        // empty the headline and append the span to it
-        element.innerHTML = '';
-        element.appendChild(firstWord);
-
-        // add the rest of the element back to it
-        element.innerHTML += ' ' + elementWords.join(' ');
-
-        // update the first word variable in the dom
-        firstWord = document.getElementById('element-first-word');
-
-        firstWordHeight = firstWord.offsetHeight;
-        elementHeight = element.offsetHeight;
-        // restore the original element text
-        element.innerHTML = ORIGINAL_ELEMENT_TEXT;
-
-        // compare the height of the element and the height of the first word
-        return elementHeight - HEIGHT_OFFSET > firstWordHeight;
-
-    } // end textElementIsMultipleLines
+        var elementStyles = window.getComputedStyle(element);
+        var elementLineHeight = parseInt(elementStyles['line-height'], 10);
+        var elementHeight = parseInt(elementStyles['height'], 10);
+        return elementLineHeight < elementHeight;
+    }
 
     return {
         initialize: initialize,


### PR DESCRIPTION
Assess the headline by comparing the content height to the line-height.

It’s roughly 4500% faster than the original ([benchmark](https://measurethat.net/Benchmarks/Show/14554/0/multi-line-detection-methods-2#latest_results_block)). It also doesn’t have the problems calculating the multilinedness of headlines that contain HTML formatting. (The original might inadvertently make the headline longer.)